### PR TITLE
Feat: Add cypress tests to device wearer list view (+ refactoring views)

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
+import dataPlatformApi from './integration_tests/mockApis/dataPlatformApi'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -22,6 +23,7 @@ export default defineConfig({
         reset: resetStubs,
         ...auth,
         ...tokenVerification,
+        ...dataPlatformApi,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/feature.env
+++ b/feature.env
@@ -1,6 +1,7 @@
 PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
+ELECTRONIC_MONITORING_API_URL=http://localhost:9091
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development
 API_CLIENT_ID=clientid

--- a/integration_tests/e2e/deviceWearer/list.cy.ts
+++ b/integration_tests/e2e/deviceWearer/list.cy.ts
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+import DeviceWearerListPage from '../../pages/deviceWearer/list'
+import Page from '../../pages/page'
+
+context('Device Wearer List', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('should display the device wearers view', () => {
+    cy.task('stubDeviceWearers')
+    cy.signIn()
+    cy.visit('/device-wearers')
+
+    Page.verifyOnPage(DeviceWearerListPage)
+  })
+
+  it('should display three device wearers in a data table', () => {
+    cy.task('stubDeviceWearers')
+    cy.signIn()
+    cy.visit('/device-wearers')
+
+    const page = Page.verifyOnPage(DeviceWearerListPage)
+
+    page.dataTable().should('exist')
+    page.dataTableBodyRows().should('have.lengthOf', 2)
+  })
+
+  it('should display a warning when no results are returned', () => {
+    cy.task('stubDeviceWearersEmptyResponse')
+    cy.signIn()
+    cy.visit('/device-wearers?search=')
+
+    const page = Page.verifyOnPage(DeviceWearerListPage)
+
+    page.dataTable().should('exist')
+    page.dataTableBodyRows().should('have.lengthOf', 1)
+    page.dataTableBodyRows().should('contain', 'No results matching search term')
+  })
+})

--- a/integration_tests/mockApis/dataPlatformApi.ts
+++ b/integration_tests/mockApis/dataPlatformApi.ts
@@ -1,0 +1,59 @@
+import { stubFor } from './wiremock'
+
+const stubDeviceWearers = () => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/device-wearers/v1',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;',
+      },
+      jsonBody: {
+        error: '',
+        deviceWearers: [
+          {
+            id: 1,
+            deviceWearerId: '3fc55bb7-ba52-4854-be96-661f710328fc',
+            firstName: 'John',
+            lastName: 'Smith',
+            type: 'Historical Case Centric',
+          },
+          {
+            id: 2,
+            deviceWearerId: 'ba34370c-9bf7-44eb-943e-2a6566205f99',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            type: 'Historical User Centric',
+          },
+        ],
+      },
+    },
+  })
+}
+
+const stubDeviceWearersEmptyResponse = () => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/device-wearers/v1',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;',
+      },
+      jsonBody: {
+        error: '',
+        deviceWearers: [],
+      },
+    },
+  })
+}
+
+export default {
+  stubDeviceWearers,
+  stubDeviceWearersEmptyResponse,
+}

--- a/integration_tests/pages/deviceWearer/list.ts
+++ b/integration_tests/pages/deviceWearer/list.ts
@@ -3,7 +3,7 @@ import { PageElement } from '../page'
 
 export default class DeviceWearerListPage extends AuthenticatedPage {
   constructor() {
-    super('Device Wearers')
+    super('Search for a device wearer')
   }
 
   dataTable = (): PageElement => cy.get('.govuk-table')

--- a/integration_tests/pages/deviceWearer/list.ts
+++ b/integration_tests/pages/deviceWearer/list.ts
@@ -1,0 +1,18 @@
+import AuthenticatedPage from '../authenticatedPage'
+import { PageElement } from '../page'
+
+export default class DeviceWearerListPage extends AuthenticatedPage {
+  constructor() {
+    super('Device Wearers')
+  }
+
+  dataTable = (): PageElement => cy.get('.govuk-table')
+
+  dataTableHeader = (): PageElement => this.dataTable().get('thead')
+
+  dataTableHeaderRows = (): PageElement => this.dataTable().get('tr')
+
+  dataTableBody = (): PageElement => this.dataTable().get('tbody')
+
+  dataTableBodyRows = (): PageElement => this.dataTableBody().find('tr')
+}

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -7,6 +7,4 @@ export default class IndexPage extends AuthenticatedPage {
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')
-
-  courtRegisterLink = (): PageElement => cy.get('[href="/court-register"]')
 }

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -1,6 +1,6 @@
 import passport from 'passport'
 import { Strategy } from 'passport-oauth2'
-import type { RequestHandler } from 'express'
+import type { RequestHandler, Request } from 'express'
 
 import config from '../config'
 import generateOauthClientToken from './clientCredentials'
@@ -17,6 +17,7 @@ passport.deserializeUser((user, done) => {
 })
 
 export type AuthenticationMiddleware = (tokenVerifier: TokenVerifier) => RequestHandler
+export type AuthenticatedRequest = Request & { user: Express.User }
 
 const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
   return async (req, res, next) => {

--- a/server/routes/deviceWearerController.ts
+++ b/server/routes/deviceWearerController.ts
@@ -1,74 +1,50 @@
-import type { NextFunction, Request, Response } from 'express'
-import logger from '../../logger'
-import { DeviceWearerResponse } from '../data_models/deviceWearer'
-
+import type { Response } from 'express'
 import DeviceWearerService from '../services/deviceWearerService'
-
-export type ListDeviceWearersRequest = Request & { user: Express.User }
+import { AuthenticatedRequest } from '../authentication/auth'
+import { DeviceWearerDetailViewModel, DeviceWearerListViewModel } from '../viewModels/DeviceWearer'
 
 export default class DeviceWearerController {
   constructor(private readonly deviceWearerService: DeviceWearerService) {}
 
-  async listDeviceWearers({ user }: ListDeviceWearersRequest, res: Response) {
+  // Ensure the data passed to the view conforms to the model
+  private renderDeviceWearerListView(res: Response, data: DeviceWearerListViewModel): void {
+    res.render('pages/deviceWearer/list', data)
+  }
+
+  // Ensure the data passed to the view conforms to the model
+  private renderDeviceWearerDetailView(res: Response, data: DeviceWearerDetailViewModel): void {
+    res.render('pages/deviceWearer/detail', data)
+  }
+
+  async listDeviceWearers({ user, query: { search = '' } }: AuthenticatedRequest, res: Response) {
     try {
-      const deviceWearerResponse: DeviceWearerResponse = await this.deviceWearerService.findMany(
-        user.token,
-        '' /* req.query.searchTerm */,
-      )
-      if (deviceWearerResponse.deviceWearers.length === 0) {
-        res.render('pages/apiError', { errorMessage: deviceWearerResponse.error })
-      } else {
-        res.render('pages/deviceWearer/list', { deviceWearers: deviceWearerResponse.deviceWearers, isError: false })
-      }
-    } catch (e) {
-      res.render('pages/apiError', { errorMessage: 'Something has gone wrong, sorry!' })
+      const deviceWearerResponse = await this.deviceWearerService.findMany(user.token, search.toString())
+      this.renderDeviceWearerListView(res, {
+        deviceWearers: deviceWearerResponse.deviceWearers,
+        error: null,
+        searchTerm: search.toString(),
+      })
+    } catch (err) {
+      this.renderDeviceWearerListView(res, {
+        deviceWearers: [],
+        error: err.message,
+        searchTerm: search.toString(),
+      })
     }
   }
 
-  async viewDeviceWearer({ user, params }: Request, res: Response, next: NextFunction) {
-    if (user) {
-      try {
-        const deviceWearerResponse: DeviceWearerResponse = await this.deviceWearerService.findOne(user.token, params.id)
-        // res.render('pages/deviceWearer/detail', { deviceWearer: deviceWearerResponse.deviceWearers[0], errorMessage: deviceWearerResponse.error })
-        if (deviceWearerResponse.deviceWearers.length === 0) {
-          res.render('pages/apiError', { errorMessage: deviceWearerResponse.error })
-        } else {
-          res.render('pages/deviceWearer/detail', {
-            deviceWearer: deviceWearerResponse.deviceWearers[0],
-            isError: false,
-          })
-        }
-      } catch (err) {
-        next(err)
-      }
-    } else {
-      res.render('pages/authError/noUser')
-    }
-  }
-
-  async searchDeviceWearer({ user, query }: Request, res: Response, next: NextFunction) {
-    if (user) {
-      try {
-        if (query.search == null) {
-          res.render('pages/deviceWearer/search')
-        } else {
-          logger.debug(
-            `calling deviceWearerController.searchDeviceWearer, with searchParams ${query.search.toString()}`,
-          )
-          const searchParam = query.search.toString()
-          const deviceWearerResponse: DeviceWearerResponse = await this.deviceWearerService.findMany(
-            user.token,
-            searchParam,
-          )
-          if (deviceWearerResponse.deviceWearers.length === 0) {
-            res.render('pages/apiError', { errorMessage: deviceWearerResponse.error })
-          } else {
-            res.render('pages/deviceWearer/list', { deviceWearers: deviceWearerResponse.deviceWearers, isError: false })
-          }
-        }
-      } catch (err) {
-        next(err)
-      }
+  async viewDeviceWearer({ user, params: { deviceWearerId } }: AuthenticatedRequest, res: Response) {
+    try {
+      const deviceWearerResponse = await this.deviceWearerService.findOne(user.token, deviceWearerId)
+      this.renderDeviceWearerDetailView(res, {
+        deviceWearer: deviceWearerResponse.deviceWearers[0],
+        error: null,
+      })
+    } catch (err) {
+      this.renderDeviceWearerDetailView(res, {
+        deviceWearer: null,
+        error: err.message,
+      })
     }
   }
 }

--- a/server/routes/deviceWearerController.ts
+++ b/server/routes/deviceWearerController.ts
@@ -21,12 +21,13 @@ export default class DeviceWearerController {
       const deviceWearerResponse = await this.deviceWearerService.findMany(user.token, search.toString())
       this.renderDeviceWearerListView(res, {
         deviceWearers: deviceWearerResponse.deviceWearers,
-        error: null,
+        isError: false,
         searchTerm: search.toString(),
       })
     } catch (err) {
       this.renderDeviceWearerListView(res, {
         deviceWearers: [],
+        isError: true,
         error: err.message,
         searchTerm: search.toString(),
       })
@@ -38,12 +39,13 @@ export default class DeviceWearerController {
       const deviceWearerResponse = await this.deviceWearerService.findOne(user.token, deviceWearerId)
       this.renderDeviceWearerDetailView(res, {
         deviceWearer: deviceWearerResponse.deviceWearers[0],
-        error: null,
+        isError: false,
       })
     } catch (err) {
       this.renderDeviceWearerDetailView(res, {
         deviceWearer: null,
         error: err.message,
+        isError: true,
       })
     }
   }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,9 +2,9 @@ import { type RequestHandler, Router } from 'express'
 
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
-import type { ListDeviceWearersRequest } from './deviceWearerController'
 
 import DeviceWearerController from './deviceWearerController'
+import { AuthenticatedRequest } from '../authentication/auth'
 // import logger from '../../logger'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -20,21 +20,10 @@ export default function routes(service: Services): Router {
   })
 
   // DeviceWearer routes
-  router.get('/device-wearers', (req, res) =>
-    deviceWearerController.listDeviceWearers(req as ListDeviceWearersRequest, res),
+  get('/device-wearers', (req: AuthenticatedRequest, res) => deviceWearerController.listDeviceWearers(req, res))
+  get('/device-wearers/id/:deviceWearerId', (req: AuthenticatedRequest, res) =>
+    deviceWearerController.viewDeviceWearer(req, res),
   )
-  router.get('/device-wearers/id/:id', (req, res, next) => {
-    deviceWearerController.viewDeviceWearer(req, res, next)
-  })
-  router.get('/device-wearers/search', (req, res, next) => {
-    deviceWearerController.searchDeviceWearer(req, res, next)
-  })
-
-  // Other routes
-  router.get('/hello-dev-api', (req, res) =>
-    res.redirect('https://api.electronic-monitoring-dev.hmpps.service.justice.gov.uk/hello/v1'),
-  )
-  router.get('/hello-local-api', (req, res) => res.redirect('http://localhost:8081/hello/v1'))
 
   return router
 }

--- a/server/viewModels/DeviceWearer.ts
+++ b/server/viewModels/DeviceWearer.ts
@@ -1,0 +1,14 @@
+import { BaseErrorModel, BaseSuccessModel } from '.'
+import { DeviceWearer } from '../data_models/deviceWearer'
+
+// deviceWearers MUST be an empty list if an error occured
+// error MUST be null if there are 0 or more deviceWearers
+type DeviceWearerListViewModel =
+  | (BaseErrorModel & { deviceWearers: []; searchTerm: string })
+  | (BaseSuccessModel & { deviceWearers: Array<DeviceWearer>; searchTerm: string })
+
+type DeviceWearerDetailViewModel =
+  | (BaseErrorModel & { deviceWearer: null })
+  | (BaseSuccessModel & { deviceWearer: NonNullable<DeviceWearer> })
+
+export { DeviceWearerListViewModel, DeviceWearerDetailViewModel }

--- a/server/viewModels/index.ts
+++ b/server/viewModels/index.ts
@@ -1,0 +1,9 @@
+type BaseErrorModel = {
+  error: NonNullable<string>
+}
+
+type BaseSuccessModel = {
+  error: null
+}
+
+export { BaseErrorModel, BaseSuccessModel }

--- a/server/viewModels/index.ts
+++ b/server/viewModels/index.ts
@@ -1,9 +1,10 @@
 type BaseErrorModel = {
+  isError: true
   error: NonNullable<string>
 }
 
 type BaseSuccessModel = {
-  error: null
+  isError: false
 }
 
 export { BaseErrorModel, BaseSuccessModel }

--- a/server/views/pages/deviceWearer/detail.njk
+++ b/server/views/pages/deviceWearer/detail.njk
@@ -5,7 +5,6 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
 
 {% set deviceWearerDetailsHtml %}
     <h2 class="govuk-heading-l">Device wearer details</h2>

--- a/server/views/pages/deviceWearer/list.njk
+++ b/server/views/pages/deviceWearer/list.njk
@@ -1,10 +1,13 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
+{% from "moj/components/search/macro.njk" import mojSearch %}
+{% from "../../partials/dataTable.njk" import dataTable %}
+{% from "../../partials/search.njk" import search %}
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
 
 {% set rows = [] %}
 
@@ -35,43 +38,44 @@
 
 {% block content %}
 
-  <h1>Device Wearers</h1>
+  {%if error %}
 
-  {%if isError %}
-
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: [
-        {
-          text: "Could not fetch data from remote API",
-          href: "#"
-        }
-      ]
+    {{ mojBanner({
+      text: error,
+      type: 'warning'
     }) }}
 
   {% endif %}
 
-  {{ govukTable({
-    captionClasses: "govuk-table__caption--l",
-    firstCellIsHeader: true,
-    head: [
-      {
-        text: "Device Wearer ID"
-      },
-      {
-        text: "First Name"
-      },
-      {
-        text: "Last Name"
-      },
-      {
-        text: "Type"
-      },
-      {
-        text: "Actions"
-      }
-    ],
-    rows: rows
-  }) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+      {{ search({
+          action: '',
+          method: 'get',
+          input: {
+            id: 'search',
+            name: 'search'
+          },
+          label: {
+            text: "Search for a device wearer",
+            classes: 'govuk-label--l'
+          },
+          hint: {
+            text: "This search will attempt to match your whole input to any part of any field"
+          },
+          button: {
+            text: 'Search'
+          },
+          value: searchTerm
+        }) }}
+    </div>
+  </div>
+
+  {{
+    dataTable(
+      ["Device Wearer ID", "First Name", "Last Name", "Type", "Actions"],
+      rows
+    )
+  }}
 
 {% endblock %}

--- a/server/views/pages/deviceWearer/list.njk
+++ b/server/views/pages/deviceWearer/list.njk
@@ -38,7 +38,7 @@
 
 {% block content %}
 
-  {%if error %}
+  {%if isError %}
 
     {{ mojBanner({
       text: error,

--- a/server/views/pages/deviceWearer/list.njk
+++ b/server/views/pages/deviceWearer/list.njk
@@ -29,10 +29,13 @@
 {% endfor %}
 
 {% block beforeContent %}
+  {{ super() }}
   {{ govukBackLink({ href: "/", text: "Back" }) }}
 {% endblock %}
 
 {% block content %}
+
+  <h1>Device Wearers</h1>
 
   {%if isError %}
 
@@ -49,7 +52,6 @@
   {% endif %}
 
   {{ govukTable({
-    caption: "Device Wearers",
     captionClasses: "govuk-table__caption--l",
     firstCellIsHeader: true,
     head: [

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -3,7 +3,6 @@
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 

--- a/server/views/partials/dataTable.njk
+++ b/server/views/partials/dataTable.njk
@@ -1,0 +1,32 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro dataTable(columns, rows) %}
+
+  {% set renderedRows = [[ {
+    text: "No results matching search term",
+    colspan: columns | length,
+    classes: "govuk-\!-text-align-centre"
+    } ]]
+  %}
+
+  {% if rows | length %}
+    {% set renderedRows = rows %}
+  {% endif %}
+
+  {% set renderedColumns = [] %}
+
+  {% for column in columns %}
+    {% set renderedColumns = (renderedColumns.push(
+      {
+        text: column
+      }
+    ), renderedColumns) %}
+  {% endfor %}
+
+  {{ govukTable({
+    head: renderedColumns,
+    rows: renderedRows
+  }) }}
+
+{% endmacro %}
+

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -2,6 +2,10 @@
 
 {% extends "govuk/template.njk" %}
 
+
+{% set mainClasses = "app-container govuk-body govuk-!-padding-top-4" %}
+
+
 {% block head %}
   <!--[if !IE 8]><!-->
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>

--- a/server/views/partials/search.njk
+++ b/server/views/partials/search.njk
@@ -1,0 +1,38 @@
+{% macro search(params) %}
+  {%- from "govuk/components/input/macro.njk" import govukInput %}
+    {%- from "govuk/components/button/macro.njk" import govukButton %}
+
+    <div class="moj-search {{- ' ' + params.classes if params.classes}}">
+
+    {%- if params.hint %}
+        {% set hintClasses = 'moj-search__hint ' + (params.hint.classes if params.hint.classes) %}
+        {% set hintText = params.hint.text %}
+        {% set hint = { classes: hintClasses, text: hintText } %}
+    {% endif -%}
+
+    {%- if params.method %}
+        {% set method = params.method %}
+    {% endif -%}
+
+    <form action="{{ params.action }}" method="{{ params.method | default('get') }}">
+        {{ govukInput({
+        classes: 'moj-search__input ' + (params.input.classes if params.input.classes),
+        label: {
+            classes: 'moj-search__label ' + (params.label.classes if params.label.classes),
+            text: params.label.text,
+            isPageHeading: true
+        },
+        hint: hint,
+        id: params.input.id,
+        name: params.input.name,
+        type: 'search',
+        value: params.value
+        }) }}
+
+        {{ govukButton({
+        classes: 'moj-search__button ' + (params.button.classes if params.button.classes),
+        text: params.button.text
+        }) }}
+    </form>
+    </div>
+{% endmacro %}


### PR DESCRIPTION
This PR hopefully simplifies the device wearer controller whilst achieving the same functionality. Also amalgamates the search and list view as they are essentially the same. All backend logic stays the same.

Changes:
- Added the search macro
  - Extends the mojSearch macro to persist the searchTerm between page loads
- Added dataTable macro to handle common functionality
  - Specifically empty data sets
-  Renamed `ListDeviceWearersRequest` to `AuthenticatedRequest` and moved it to a more generic place
   - Happy to move this to somewhere more appropriate
- Added view models for all device wearer views
  - This just builds on what was already there
  - To make this work well, we need to enable `strictNullChecks` but that breaks a lot of the boilerplate code
- Refactored the deviceWearerController
  - Rendering separates views for errors creates a poor user experience so this should keep them on the same pages where they can continue their journeys
  - A search that results in no data is not an error
  - Authentication errors should not be handled by this controller
  - The user does not care if there is an `apiError` so this stops using that view